### PR TITLE
#feat : Task 생성 세부 기능 구현 및 디자인 적용

### DIFF
--- a/components/cardForm.js
+++ b/components/cardForm.js
@@ -77,8 +77,8 @@ export default function CardForm() {
     return (
         `
             <form class="card_form card surface-default shadow-normal rounded-100">
-                <input name="title" class="text-strong display-bold14" type="text" placeholder="제목을 입력하세요"/>
-                <input name="content" class="text-default display-medium14" type="text" placeholder="내용을 입력하세요"/>
+                <input name="title" class="text-strong display-bold14" type="text" placeholder="제목을 입력하세요" maxlength="500" />
+                <input name="content" class="text-default display-medium14" type="text" placeholder="내용을 입력하세요" maxlength="500" />
                 <span>
                     <button class="rounded-100 surface-alt text-default display-bold14" type="button">취소</button>
                     <button class="rounded-100 surface-brand text-white-default display-bold14 disabled" disabled type="submit">제출</button>

--- a/public/main.css
+++ b/public/main.css
@@ -41,7 +41,24 @@ main {
 
 .column_button_container {
     margin-left: auto;
+
+    >button {
+        &:first-of-type {
+            &:hover {
+                filter: invert(34%) sepia(33%) saturate(6685%) hue-rotate(200deg) brightness(102%) contrast(106%);
+            }
+
+        }
+
+        &:last-of-type {
+            &:hover {
+                filter: invert(35%) sepia(50%) saturate(6582%) hue-rotate(343deg) brightness(110%) contrast(99%);
+            }
+        }
+    }
 }
+
+
 
 .card {
     display: flex;

--- a/public/main.css
+++ b/public/main.css
@@ -15,12 +15,13 @@ main {
     width: 320px;
     min-width: 320px;
     margin-right: 32px;
+
     &:last-of-type {
         margin: 0;
     }
 }
 
-.column > ol {
+.column>ol {
     list-style-type: none;
 }
 
@@ -28,6 +29,7 @@ main {
     display: flex;
     align-items: center;
     padding: 0 16px;
+
     span {
         display: flex;
 
@@ -69,6 +71,8 @@ main {
 
 .card_text_container {
     flex-grow: 1;
+    word-break: break-all;
+
     h4 {
         margin-bottom: 8px;
     }

--- a/script/column.js
+++ b/script/column.js
@@ -5,6 +5,14 @@ import { createTask } from './task.js';
 
 export function createTaskForm(columnIdx) {
     const cardFormArea = document.getElementsByClassName("card_add")[columnIdx];
+    
+    // 이미 Form이 존재하는 경우, + 버튼으로 존재하는 Form을 닫기
+    const isCardFormExists = cardFormArea.children.length !== 0;
+    if(isCardFormExists) {
+        cardFormArea.removeChild(cardFormArea.children[0])
+        return;
+    }
+
     cardFormArea.innerHTML = CardForm();
     const forms = document.getElementsByClassName('card_form');
     


### PR DESCRIPTION
## 주요 작업
- [x]  1. task 생성 - 리스트에 새 task 추가 및 form 제작
    - [x]  hover 스타일 변경
    - [x]  컨텐츠 유무에 의한 비활성화
    - [x]  글자 수 제한 (500)
    - [x]  + 버튼으로 task form toggle 하기
  
## 학습 키워드
CSS, JavaScript 이벤트

## 고민과 해결과정
1. element.children과 element.firstChild의 차이점
   - +버튼으로 task를 생성하기 위한 Form을 만든다. 만일 Form이 이미 존재한다면 +버튼을 눌렀을 때, Form을 지운다.
   - 해당 문제를 해결하기 위해 "card_add" class 명을 가진 div가 가진 child로 해당 문제를 해결하려 하였다.
   - 기존에 작성해둔 코드로는 "card_add" div에는 하나의 Form만 존재하기에 firstNode를 removeChild로 삭제하였으나 Form이 남아있는 문제를 확인할 수 있었다.
   - console로 firstChild와 childNodes를 확인한 결과 
   - <img width="784" alt="image" src="https://github.com/user-attachments/assets/b51334cb-0565-41a4-bc99-9a9d6292f698" />
   - 다음과 같이 NodeList에는 form 하나만 있는 것이 아닌 text 노드들이 존재하는 것을 확인할 수 있었다.
   - [firstChild](https://developer.mozilla.org/ko/docs/Web/API/Node/firstChild) 문서를 확인한 결과, 공백 같은 텍스트또한 노드로 인식이 된다는 것을 알 수 있었고 모든 Node를 탐지하는 것이 아닌 HTMLElement를 탐지하기 위해 element.children으로 Form을 찾을 수 있었다.
   ```
    const isCardFormExists = cardFormArea.children.length !== 0;
    if(isCardFormExists) {
        cardFormArea.removeChild(cardFormArea.children[0])
        return;
    }
   ```
   - 다음과 children이 존재하는 경우, 첫 번째 Element를 삭제함으로서 Form을 toggle할 수 있는 기능을 구현하였다.

2. svg 스타일링
   - Column의 +, x 버튼에 마우스를 hover하면 스타일이 변경되는 기능이 필요하였다. 
   - img태그로 src로 불러온 경우, 직접적인 스타일 조정이 불가능하여, 2가지 선택지가 존재하였다.
   - 1. 변경될 색상의 svg를 생성하여 src를 js로 동적으로 변경하는 것, 2. CSS filter를 사용하여 hover시 색상을 변경하는 것
   - 이번 프로젝트에서는 CSS에 조금 더 익숙해지고 자주 사용하지 않았던 filter를 사용해보고자 2번을 선택하였다.
   - [CSS filter Generator](https://codepen.io/sosuke/pen/Pjoqqp) 검색을 통해 원하는 색상으로 변화시킬 수 있는 filter 생성기가 존재하여 이를 사용하여 CSS를 적용시킬 수 있었다.