### PR TITLE
#refactor : Apply Move Task animation / combine rerender column header to renderColumn function

### DIFF
--- a/components/column.js
+++ b/components/column.js
@@ -48,7 +48,7 @@ export default function ColumnComponent() {
         addButton.addEventListener("click", () =>
             handleAdd(formContainer, columnIdx)
         );
-        const listElement = columnElement.querySelector('.card_list')
+        const listElement = columnElement.querySelector(".card_list");
         listElement.addEventListener("dragover", (e) => e.preventDefault());
         listElement.addEventListener("drop", handleDrop);
         listElement.addEventListener("dragenter", handleDragEnter);
@@ -60,12 +60,6 @@ export default function ColumnComponent() {
             ".column_task_counter"
         )[idx];
         if (n > MAX_TASKS) counterElement.textContent`${MAX_TASKS}+`;
-        else counterElement.textContent = n;
-    }
-
-    function rerenderHeader(idx, n) {
-        const counterElement = document.body.querySelectorAll('.column_task_counter')[idx];
-        if(n > MAX_TASKS) counterElement.textContent `${MAX_TASKS}+`;
         else counterElement.textContent = n;
     }
 

--- a/components/task.js
+++ b/components/task.js
@@ -52,8 +52,6 @@ export default function TaskComponent() {
         deleteButton.addEventListener("click", handleRemove );
         editButton.addEventListener("click", handleUpdate );   
     
-        taskElement.addEventListener('dragenter',(e)=>e.stopPropagation());
-        // taskElement.addEventListener('dragleave',(e)=>e.stopPropagation());
         taskElement.addEventListener("dragstart", handleDrag);
     }
 


### PR DESCRIPTION
## 주요 작업
Task 이동 애니메이션 적용

## 학습 키워드
기능 분리

## 고민과 해결과정
1. 기능 분리
- 기능을 명확하게 하기 위해서 기존에 Column의 task 개수 변화시 Header Rerender 함수를 renderColumn과 분리되어 있는 것을 renderColumn에서 현재 Task의 개수와 생성되어야할 Task의 개수를 비교하여 rerenderHeader를 진행할 수 있도록 기능 분리

2. insertBefore 사용
- 기존에 Dummy Task(잔상)을 항상 Column의 마지막 위치에 삽입하던 것을 미리 Task가 렌더링 될 위치를 계산하여 InsertBefore로 잔상을 올바른 위치에 생성되도록 적용

3. Container Drop 이벤트 적용
- Drop 이벤트가 일어나는 리스트 Element 밖에다가 drop을 하게 되는 경우, Task Element가 투명상태에서 해제되지 않던 문제를 Container Element에도 Drop 이벤트를 적용시켜 문제를 해결
- 이 과정에서 리스트 Element에서 drop시, event가 bubbling 되는 것을 방지하기 위해 event.stopPropagation을 사용하여 상위 컴포넌트로 이벤트 버블링을 방지