### PR TITLE
#feat : 컬럼 추가 / 삭제 / 수정 기능 구현

### DIFF
--- a/components/column.js
+++ b/components/column.js
@@ -1,10 +1,13 @@
 export default function ColumnComponent() {
+
     // Column 컴포넌트 템플릿
     function template({ title }) {
         return `
-            <h3 class="column_title text-bold display-bold16">
-                ${title}
-                <span class="column_task_counter text-weak display-medium12 border-default rounded-100">0</span>
+            <h3 class="column_header text-bold display-bold16">
+                <span class="column_title_container">
+                    <span class="column_title">${title}</span>
+                    <span class="column_task_counter text-weak display-medium12 border-default rounded-100">0</span>
+                </span>
                 <span class="column_button_container">
                     <button>
                         <img draggable="false" width="24" height="24" src="/public/icon/plus.svg" />
@@ -38,11 +41,12 @@ export default function ColumnComponent() {
         handleAdd,
         handleDrop,
         handleDragEnter,
-        handleDragLeave
+        handleDragLeave,
+        handleBlur
     ) {
         const [addButton, removeButton] =
             columnElement.getElementsByTagName("button");
-        const columnIdx = columnElement.getAttribute("index");
+        const columnIdx = Number(columnElement.getAttribute("index"));
         const formContainer =
             columnElement.getElementsByClassName("card_add")[0];
         addButton.addEventListener("click", () =>
@@ -53,6 +57,13 @@ export default function ColumnComponent() {
         listElement.addEventListener("drop", handleDrop);
         listElement.addEventListener("dragenter", handleDragEnter);
         listElement.addEventListener("dragleave", handleDragLeave);
+
+        const titleElement = columnElement.querySelector('.column_title_container');
+        const editElement = renderEditForm(titleElement, (title)=>handleBlur(columnIdx, title))
+        titleElement.addEventListener('dblclick', ()=>{
+            titleElement.parentNode.replaceChild(editElement, titleElement);
+            editElement.focus();
+        })
     }
 
     function rerenderHeader(idx, n) {
@@ -61,6 +72,22 @@ export default function ColumnComponent() {
         )[idx];
         if (n > MAX_TASKS) counterElement.textContent`${MAX_TASKS}+`;
         else counterElement.textContent = n;
+    }
+
+    function renderEditForm(containerElement, handleBlur) {
+        const titleElement = containerElement.querySelector('.column_title');
+        const title = titleElement.textContent;
+        const inputElement = document.createElement('input');
+        inputElement.classList = 'border-default surface-default display-medium14 text-strong'
+        inputElement.value = title;
+
+        inputElement.addEventListener('blur', (e)=>{
+            titleElement.textContent = e.target.value;
+            inputElement.parentNode.replaceChild(containerElement, inputElement);
+            handleBlur(e.target.value);
+        });
+
+        return inputElement;
     }
 
     return {

--- a/components/column.js
+++ b/components/column.js
@@ -42,17 +42,21 @@ export default function ColumnComponent() {
         handleDrop,
         handleDragEnter,
         handleDragLeave,
-        handleBlur
+        handleBlur,
+        handleContextMenu
     ) {
         const [addButton, removeButton] =
             columnElement.getElementsByTagName("button");
         const columnIdx = Number(columnElement.getAttribute("index"));
         const formContainer =
             columnElement.getElementsByClassName("card_add")[0];
+        
         addButton.addEventListener("click", () =>
             handleAdd(formContainer, columnIdx)
         );
+
         const listElement = columnElement.querySelector(".card_list");
+        
         listElement.addEventListener("dragover", (e) => e.preventDefault());
         listElement.addEventListener("drop", handleDrop);
         listElement.addEventListener("dragenter", handleDragEnter);
@@ -60,6 +64,8 @@ export default function ColumnComponent() {
 
         const titleElement = columnElement.querySelector('.column_title_container');
         const editElement = renderEditForm(titleElement, (title)=>handleBlur(columnIdx, title))
+        
+        titleElement.addEventListener('contextmenu', handleContextMenu)
         titleElement.addEventListener('dblclick', ()=>{
             titleElement.parentNode.replaceChild(editElement, titleElement);
             editElement.focus();
@@ -90,10 +96,15 @@ export default function ColumnComponent() {
         return inputElement;
     }
 
+    function remove(columnElement) {
+        columnElement.remove()
+    }
+
     return {
         render,
         addEventListener,
         rerenderHeader,
+        remove,
     };
 }
 

--- a/public/globals.css
+++ b/public/globals.css
@@ -5,6 +5,8 @@
     padding: 0;
     box-sizing: border-box;
 
+    font-family: "Pretendard";
+
     ::-webkit-scrollbar {
         display: none;
       }
@@ -18,7 +20,6 @@ button {
 
 body {
     position: relative;
-    font-family: "Pretendard";
 }
 
 :root {

--- a/public/icon/plus_white.svg
+++ b/public/icon/plus_white.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.6667 8.66533H8.66668V12.6653H7.33334V8.66533H3.33334V7.332H7.33334V3.332H8.66668V7.332H12.6667V8.66533Z" fill="#EFEFEF"/>
+</svg>

--- a/public/main.css
+++ b/public/main.css
@@ -42,9 +42,10 @@ header > span {
     list-style-type: none;
 }
 
-.column_title {
+.column_header {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     padding: 0 16px;
 
     span {
@@ -56,10 +57,24 @@ header > span {
             justify-content: center;
         }
     }
+
+    input {
+        width: 100%;
+        outline: none;
+        border-radius: 6px;
+        padding: 0 8px;
+        height: 24px;
+    }
+}
+
+.column_title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .column_button_container {
-    margin-left: auto;
+    margin-left: 8px;
 
     >button {
         &:first-of-type {

--- a/script/column.js
+++ b/script/column.js
@@ -194,7 +194,7 @@ export default function ColumnController(state, bodyElement, logStore) {
         const newTask = {
             title: title,
             content: content,
-            column: Number(columnIdx),
+            column: columnIdx,
             created: new Date(),
         };
 
@@ -241,7 +241,8 @@ export default function ColumnController(state, bodyElement, logStore) {
                     renderAddForm(formContainer, columnIdx),
                 handleDrop,
                 handleDragEnter,
-                handleDragLeave
+                handleDragLeave,
+                (index, title)=>state.editColumn(index, title)
             );
             columnListFragment.appendChild(columnElement);
         }

--- a/script/column.js
+++ b/script/column.js
@@ -1,5 +1,6 @@
 import FormComponent from "../components/Form.js";
 import ColumnComponent from "../components/column.js";
+import ModalComponent from "../components/modal.js";
 import TaskController from "./task.js";
 
 export default function ColumnController(state, bodyElement, logStore) {
@@ -9,7 +10,7 @@ export default function ColumnController(state, bodyElement, logStore) {
     const taskController = TaskController(state, logStore, (idx)=>{
         renderColumn(idx, columnTasks[idx]);
     });
-    
+
     function handleDrop(e) {
         e.stopPropagation();
         const {task, element, dummyElement} = state.getDragged();
@@ -49,9 +50,9 @@ export default function ColumnController(state, bodyElement, logStore) {
 
         const tempTask = state.sortTask([...columnTasks[columnIdx], task])
         const dragIdx = tempTask.findIndex(el => el.taskId == task.taskId);
-        
+
         const targetElement = columnListElement.children[dragIdx];
-        
+
         columnListElement.insertBefore(dummyElement, targetElement);
     }
 
@@ -100,10 +101,10 @@ export default function ColumnController(state, bodyElement, logStore) {
 
         // 잔여 Task 목록
         const currentTasksWithId = Array.from(columnListElement.children).map((el) => {
-            return {
-                taskId: Number(el.getAttribute("taskid")),
-                element: el,
-            };
+                return {
+                    taskId: Number(el.getAttribute("taskid")),
+                    element: el,
+                };
         });
 
         const taskFragmentElement = document.createDocumentFragment();
@@ -112,7 +113,7 @@ export default function ColumnController(state, bodyElement, logStore) {
         for (let i=0; i<tasks.length; i++) {
             const task = tasks[i];
             const matchedIdx = _currentTasksWithId.findIndex(el => el.taskId === task.taskId);
-            
+
             // 일치하는 Element가 존재할 경우, 잔여 Task 목록에서 제거
             if(matchedIdx != -1) {
                 const matchedTask = currentTasksWithId[matchedIdx];
@@ -146,7 +147,7 @@ export default function ColumnController(state, bodyElement, logStore) {
 
         originalPosition.forEach((el)=>{
             const {top, taskId, element} = el;
-            
+
             const pos = newPosition.find(el => el.taskId === taskId);
             if(!pos) return;
 
@@ -168,7 +169,7 @@ export default function ColumnController(state, bodyElement, logStore) {
         /* GPT 도움 받은 영역 */
         // originalPosition.forEach((el)=>{
         //     const {top, taskId, element} = el;
-            
+
         //     const {top: _top, taskId: _taskId} = newPosition.find(el => el.taskId === taskId);
         //     const deltaY = top - _top;
 
@@ -226,11 +227,14 @@ export default function ColumnController(state, bodyElement, logStore) {
 
     // Column 동적 생성 및 이벤트 등록
     function renderInit() {
+        bodyElement.oncontextmenu = (e) => e.preventDefault();
         const mainElement = document.createElement("main");
         const columnContainerElement = document.createElement("ul");
         columnContainerElement.setAttribute("id", "column_container");
-        columnContainerElement.addEventListener('dragover', (e)=>e.preventDefault());
-        columnContainerElement.addEventListener('drop', resetDrop)
+        columnContainerElement.addEventListener("dragover", (e) =>
+            e.preventDefault()
+        );
+        columnContainerElement.addEventListener("drop", resetDrop);
         const columnListFragment = document.createDocumentFragment();
 
         for (let column of columnList) {
@@ -242,7 +246,8 @@ export default function ColumnController(state, bodyElement, logStore) {
                 handleDrop,
                 handleDragEnter,
                 handleDragLeave,
-                (index, title)=>state.editColumn(index, title)
+                (index, title) => state.editColumn(index, title),
+                () => removeColumn(column, columnElement)
             );
             columnListFragment.appendChild(columnElement);
         }
@@ -252,13 +257,46 @@ export default function ColumnController(state, bodyElement, logStore) {
         bodyElement.appendChild(mainElement);
     }
 
-    function rerenderTask(taskId) {
-        taskController.rerenderTask(taskId)
+    function addColumn(title) {
+        const column = state.addColumn(title);
+
+        const columnElement = columnComponent.render(column);
+        columnComponent.addEventListener(
+            columnElement,
+            (formContainer, columnIdx) =>
+                renderAddForm(formContainer, columnIdx),
+            handleDrop,
+            handleDragEnter,
+            handleDragLeave,
+            (index, title) => state.editColumn(index, title),
+            () => removeColumn(column, columnElement)
+        );
+
+        const columnContainerElement = document.querySelector("ul");
+        columnContainerElement.appendChild(columnElement);
     }
-    
+
+    function removeColumn(column, columnElement) {
+        if (column.nonRemovable) return;
+        
+        const { title, index: columnIdx } = column;
+
+        const modalComponent = ModalComponent();
+        modalComponent.render(`"${title}" 컬럼을 삭제하시겠습니까?`, () => {
+            state.removeColumn(columnIdx);
+            columnComponent.remove(columnElement);
+            logStore.clearLog();
+        });
+    }
+
+    function rerenderTask(taskId) {
+        taskController.rerenderTask(taskId);
+    }
+
     return {
         renderInit,
         renderColumn,
-        rerenderTask
+        rerenderTask,
+        addColumn,
     };
 }

--- a/script/fab.js
+++ b/script/fab.js
@@ -99,6 +99,7 @@ export default function FabController(bodyElement, state, logStore) {
     function renderInit() {
         const container = document.createElement("div");
         container.setAttribute("id", "fab_container");
+
         const redoElement = fabComponent.render("redo", "surface-default");
         fabComponent.addListener(redoElement, handleRedo);
         container.appendChild(redoElement);
@@ -106,7 +107,18 @@ export default function FabController(bodyElement, state, logStore) {
         const undoElement = fabComponent.render("undo", "surface-default");
         fabComponent.addListener(undoElement, handleUndo);
         container.appendChild(undoElement);
+
+        const addColumnElement = fabComponent.render("plus_white", "surface-brand");
+        fabComponent.addListener(addColumnElement, handleAddColumn);
+        container.appendChild(addColumnElement);
+
         bodyElement.appendChild(container);
+    }
+
+    function handleAddColumn() {
+        const title = prompt('new Column title?');
+
+        columnController.addColumn(title);
     }
 
     function flip(input) {

--- a/script/state.js
+++ b/script/state.js
@@ -7,14 +7,17 @@ export default function State() {
         {
             title: "해야할 일",
             index: 0,
+            nonRemovable: true,
         },
         {
             title: "하고 있는 일",
             index: 1,
+            nonRemovable: true,
         },
         {
             title: "완료한 일",
             index: 2,
+            nonRemovable: true,
         },
     ];
 
@@ -66,6 +69,24 @@ export default function State() {
     function editColumn(index, newTitle) {
         const columnIdx = columns.findIndex(col => col.index === index);
         columns[columnIdx] = {title: newTitle, index};
+    }
+
+    function addColumn(title) {
+        const index = columns.length;
+        const newColumn = {
+            title,
+            index,
+        };
+
+        columns.push(newColumn);
+        columnTasks.push([]);
+
+        return newColumn;
+    }
+
+    function removeColumn(index) {
+        columns = columns.filter(el => el.index !== index);
+        columnTasks = columnTasks.filter((el, idx) => idx !== index);
     }
 
     function getTask(taskId) {
@@ -131,6 +152,8 @@ export default function State() {
         resetDragged,
         getColumns,
         editColumn,
+        addColumn,
+        removeColumn,
         getTask,
         addTask,
         moveTask,

--- a/script/state.js
+++ b/script/state.js
@@ -63,6 +63,11 @@ export default function State() {
         return { columns, columnTasks };
     }
 
+    function editColumn(index, newTitle) {
+        const columnIdx = columns.findIndex(col => col.index === index);
+        columns[columnIdx] = {title: newTitle, index};
+    }
+
     function getTask(taskId) {
         for(let i =0; i<columns.length; i++) {
             const matchedTask = columnTasks[i].find(el => el.taskId === taskId)
@@ -125,6 +130,7 @@ export default function State() {
         setDragged,
         resetDragged,
         getColumns,
+        editColumn,
         getTask,
         addTask,
         moveTask,


### PR DESCRIPTION
## 주요 작업
1. 컬럼 추가 삭제 수정 기능 구현
2. 해당 기능 기획

## 학습 키워드
기능 기획

## 고민과 해결과정
### 1. 컬럼 수정
- 컬럼의 제목을 더블 클릭하여 컬럼을 수정할 수 있는 Input Element를 추가시키고 이를 적용 시키기 위해 다른 곳을 클릭하는 이벤트가 필요하였다.
- 기존 React에서 진행된다면 입력 값을 onChange 이벤트로 관리하지만 이번에는 변경된 state를 즉시 반영시킬 사항이 없기에 입력값을 state로 저장하지 않고 blur 이벤트를 사용하여 입력된 후 focus를 옮기게 될 경우, 수정이 되도록 구현하였다.
- 더블 클릭 시, Input Element를 추가하고 Blur로 자연스럽게 연결시키기 위해서 Element에 focus를 설정하였다.

### 2. 컬럼 삭제
- 컬럼 삭제의 경우 자유롭게 기획할 수 있기에, 1번에서 진행한 컬럼 수정을 변형시켜보기로 하였다. Column에 대한 조작을 Column의 헤더에서 일어날 수 있도록 Column Header에 적절하다고 판단한 이벤트는 우클릭 이벤트(Context Menu)다.
- 우클릭 시, 기존에 로그 삭제, Task 삭제와 동일한 모달이 생성되어 질문을 던지고 삭제 버튼을 클릭하면 컬럼을 삭제할 수 있도록 다른 삭제 로직과 동일한 flow를 따라갈 수 있도록 기획하였다.
- Column의 header에 contextmenu를 등록하기 위해, 윈도우에 할당되어 있는 oncontextmenu 이벤트를 column 초기 생성 시, 이벤트를 초기화 하였다.
- 다음은, Column에 할당된 Task를 전부 삭제할 필요가 있을지 고민하였는데, 현재 state에서 각 Column의 index에 task를 넣어 보관하고 있기에 Column index 자체를 삭제시켜 task를 삭제할 필요가 사라졌다.
- 그리고 기존의 로그 시스템과의 결합을 고민하였다.
**ex) 1번 컬럼에 task 생성 -> 4번 컬럼 생성 -> 4번 컬럼으로 task 이동 -> 4번 컬럼 삭제**
다음과 같은 경우, redo 혹은 undo가 column의 삭제로 인해 불가능하기에 Column 삭제 진행 시, logStore에서 clearLog로 로그를 전체 삭제시켜 발생할 수 있는 변수를 차단하였다.
- 또한, 기본 컬럼 (해야할 일, 하고 있는 일, 완료한 일)에는 nonRemovable 속성을 부여하여 기본 컬럼의 삭제를 방지하였다.

### 3. 컬럼 추가 및 옵저빙 패턴 적용(예정)
- 컬럼은 현재 Prompt를 통해서 제목을 입력받아 ColumnController에 컬럼의 생성을 요청한다. 이 과정은 초기 renderInit의 내부 반복문을 재사용하였기에 이를 추후 분리할 수 있을 것이다.
- 또한, Column을 store로 관리한다면, renderColumn을 ColumnStore에 구독시켜 자동적으로 렌더링이 발생할 수 있을 것이라 예상된다.